### PR TITLE
feat: allow to pipe child stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ jump in if you'd like to, or even ask us questions if something isn't clear.
 
 #### <a name="lifecycle"></a> `> lifecycle(name, pkg, wd, [opts]) -> Promise`
 
+##### Arguments
+
+* `opts.stdio` - the [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio)
+passed to the child process. `[0, 1, 2]` by default.
+
 ##### Example
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const chain = require('slide').chain
 const uidNumber = require('uid-number')
 const umask = require('umask')
 const which = require('which')
+const byline = require('byline')
 
 let PATH = 'PATH'
 
@@ -244,7 +245,7 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   var conf = {
     cwd: wd,
     env: env,
-    stdio: [ 0, 1, 2 ]
+    stdio: opts.stdio || [ 0, 1, 2 ]
   }
 
   if (!unsafe) {
@@ -281,6 +282,12 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
       er.errno = code
     }
     procError(er)
+  })
+  byline(proc.stdout).on('data', function (data) {
+    opts.log.verbose('lifecycle', logid(pkg, stage), 'stdout', data.toString())
+  })
+  byline(proc.stderr).on('data', function (data) {
+    opts.log.verbose('lifecycle', logid(pkg, stage), 'stderr', data.toString())
   })
   process.once('SIGTERM', procKill)
   process.once('SIGINT', procInterupt)

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,11 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -4504,6 +4509,119 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
+      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+      "dev": true,
+      "requires": {
+        "diff": "3.4.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.1.3",
+        "native-promise-only": "0.8.1",
+        "nise": "1.1.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.3"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "dev": true,
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "just-extend": {
+          "version": "1.1.22",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
+          "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
+          "dev": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
+          "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
+          "dev": true
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+          "dev": true
+        },
+        "nise": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.1.tgz",
+          "integrity": "sha512-f5DMJB0MqBaSuP2NAwPx7HyVKPdaozds0KsNe9XIP3npKWt/QUg73l5TTLRTSwfG/Y3AB0ktacuxX4QNcg6vVw==",
+          "dev": true,
+          "requires": {
+            "formatio": "1.2.0",
+            "just-extend": "1.1.22",
+            "lolex": "1.6.0",
+            "path-to-regexp": "1.7.0",
+            "text-encoding": "0.6.4"
+          },
+          "dependencies": {
+            "lolex": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+              "dev": true
+            }
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+          "dev": true
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+          "dev": true
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/npm/lifecycle#readme",
   "dependencies": {
+    "byline": "^5.0.0",
     "graceful-fs": "^4.1.11",
     "slide": "^1.1.6",
     "uid-number": "0.0.6",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "nyc": "^11.1.0",
+    "sinon": "^4.0.1",
     "standard": "^10.0.3",
     "standard-version": "^4.2.0",
     "tap": "^10.7.2",

--- a/test/fixtures/count-to-10/package.json
+++ b/test/fixtures/count-to-10/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "count-to-10",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node postinstall"
+  }
+}

--- a/test/fixtures/count-to-10/postinstall.js
+++ b/test/fixtures/count-to-10/postinstall.js
@@ -1,0 +1,5 @@
+'use strict'
+
+console.log('line 1')
+console.log('line 2')
+console.error('some error')


### PR DESCRIPTION
In order to use this for pnpm, we need the ability to listen for child's output.

I added a new option - `opts.stdio`, which, when specified, is passed to the child process.

I used byline to log every line of the child's output. This might be a bad solution. I am open for alternatives. Maybe we could just return the stdout stream by `lifecycle()`?
