### PR TITLE
fix(stdio): correct log

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function lifecycle (pkg, stage, wd, opts) {
       if ((wd.indexOf(opts.dir) !== 0 || _incorrectWorkingDirectory(wd, pkg)) &&
           !opts.unsafePerm && pkg.scripts[stage]) {
         opts.log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
-          '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
+          pkg._id, pkg.scripts[stage], '(wd=', wd, ')'
         )
         return resolve()
       }


### PR DESCRIPTION
This warning log should be corrected.
```
opts.log.warn('lifecycle', logid(pkg, stage), 'cannot run in wd',
  '%s %s (wd=%s)', pkg._id, pkg.scripts[stage], wd
)
```
[example]
`npm WARN lifecycle undefined~install: cannot run in wd %s %s (wd=%s) undefined echo > .last_update /root/github/upstream/bacardi`

[changed]
`npm WARN lifecycle undefined~install: cannot run in wd undefined echo > .last_update (wd= /root/github/upstream/bacardi )`
