### PR TITLE
fix: set only one PATH env variable for child proc

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ function makeEnv (data, opts, prefix, env) {
   if (!env) {
     env = {}
     for (var i in process.env) {
-      if (!i.match(/^npm_/)) {
+      if (!i.match(/^npm_/) && (!i.match(/^PATH$/i) || i === PATH)) {
         env[i] = process.env[i]
       }
     }


### PR DESCRIPTION
#22 caused a regression in pnpm when users had a version of npm
without the revert and a new version of pnpm with revert #22.

Old npm was duplicating the PATH env variables.
New pnpm was not overriding all of them.

Using only one PATH env variable will reduce uncertainty.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
