### PR TITLE
fix switches for alternative shells on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   } else if (process.platform === 'win32') {
     sh = process.env.comspec || 'cmd'
     // '/d /s /c' is used only for cmd.exe.
-    if (/^(?:.*\\)?cmd(?:\.exe)?$/i.test(file)) {
+    if (/^(?:.*\\)?cmd(?:\.exe)?$/i.test(sh)) {
       shFlag = '/d /s /c'
       conf.windowsVerbatimArguments = true
     }

--- a/index.js
+++ b/index.js
@@ -282,8 +282,11 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
     sh = customShell
   } else if (process.platform === 'win32') {
     sh = process.env.comspec || 'cmd'
-    shFlag = '/d /s /c'
-    conf.windowsVerbatimArguments = true
+    // '/d /s /c' is used only for cmd.exe.
+    if (/^(?:.*\\)?cmd(?:\.exe)?$/i.test(file)) {
+      shFlag = '/d /s /c'
+      conf.windowsVerbatimArguments = true
+    }
   }
 
   opts.log.verbose('lifecycle', logid(pkg, stage), 'PATH:', env[PATH])


### PR DESCRIPTION
On Windows, normalizeSpawnArguments set "/d /s /c" for any shells.
It cause exec and other methods are limited to cmd.exe as a shell.

Powershell and git-bash are often used instead of cmd.exe,
and they can recieve "-c" switch like unix shells.
So normalizeSpawnArguments is changed to set "/d /s /c" for cmd.exe,
and "-c" for others.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
