### PR TITLE
feat(process.env.path): Use platform specific path casing if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,13 @@ let PATH = 'PATH'
 // windows calls it's path 'Path' usually, but this is not guaranteed.
 if (process.platform === 'win32') {
   PATH = 'Path'
-  Object.keys(process.env).forEach(function (e) {
-    if (e.match(/^PATH$/i)) {
-      PATH = e
-    }
-  })
+  if (!process.env[PATH]) {
+    Object.keys(process.env).forEach(function (e) {
+      if (e.match(/^PATH$/i)) {
+        PATH = e
+      }
+    })
+  }
 }
 
 function logid (pkg, stage) {


### PR DESCRIPTION
Assume proper win32 path casing - only seek out alternative casing if win32 OS specific casing not present.

Re: https://github.com/npm/npm-lifecycle/issues/29