### PR TITLE
node-gyp@5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "byline": "^5.0.0",
     "graceful-fs": "^4.1.15",
-    "node-gyp": "^5.0.2",
+    "node-gyp": "^5.0.3",
     "resolve-from": "^4.0.0",
     "slide": "^1.1.6",
     "uid-number": "0.0.6",


### PR DESCRIPTION
Bumps node-gyp from ^5.0.2 to ^5.0.3 as requested in [this nodejs PR](https://github.com/nodejs/node/pull/28647)