### PR TITLE
opts.env option to set script specific enviromnent variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ jump in if you'd like to, or even ask us questions if something isn't clear.
 * `opts.stdio` - the [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 passed to the child process. `[0, 1, 2]` by default.
 
+* `opts.env` - if is an object, all its properties of type 'number' of 'string' are added to the environment before running the script
+
 ##### Example
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -443,6 +443,18 @@ function makeEnv (data, opts, prefix, env) {
     }
   }
 
+  // assign script specific environnement variables (ignores non string values)
+  if (typeof opts.env === 'object') {
+    for (var k in opts.env) {
+      if (opts.env.hasOwnProperty(k)) {
+        var v = opts.env[k]
+        if (typeof v === 'string' || typeof v === 'number') {
+          env[k] = String(v)
+        }
+      }
+    }
+  }
+
   if (prefix !== 'npm_package_') return env
 
   prefix = 'npm_config_'

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,14 @@ test('makeEnv', function (t) {
 
   const env = lifecycle.makeEnv(pkg, {
     config,
-    nodeOptions: '--inspect-brk --abort-on-uncaught-exception'
+    nodeOptions: '--inspect-brk --abort-on-uncaught-exception',
+    env: {
+      npm_lifecycle_var1: '6',
+      npm_lifecycle_var2: 7,
+      npm_lifecycle_ignored_null: null,
+      npm_lifecycle_ignored_object: { name: '8' },
+      npm_lifecycle_ignored_array: [ 10, 11 ]
+    }
   }, null, Object.assign({}, process.env))
 
   t.equal('myPackage', env.npm_package_name, 'package data is included')
@@ -43,6 +50,11 @@ test('makeEnv', function (t) {
   t.equal('2', env.npm_package_config_bar, 'package config is included')
   t.equal('4', env.npm_package_config_baz, 'package@version config is included')
   t.equal('5', env.npm_package_config_foo, 'package@version config overrides package config')
+  t.equal('6', env.npm_lifecycle_var1, 'env string option is included')
+  t.equal('7', env.npm_lifecycle_var2, 'env number option is included')
+  t.equal(undefined, env.npm_lifecycle_ignored_null, 'env null options are ignored')
+  t.equal(undefined, env.npm_lifecycle_ignored_object, 'env object options are ignored')
+  t.equal(undefined, env.npm_lifecycle_ignored_array, 'env array options are ignored')
 
   t.equal('--inspect-brk --abort-on-uncaught-exception', env.NODE_OPTIONS, 'nodeOptions sets NODE_OPTIONS')
   t.end()


### PR DESCRIPTION
Added support for an **env** in the opts of makeEnv() (and therefore **lifecycle()**).

The original need is to set an environment variable with the path of the generated archive before invoking **postpack** script in npm/cli.

makeEnv() has a env parameter, but :
- it ignores any variables beginning with "npm_"
- it is not available in lifecycle()

The proposed implementation ignores all opts.env properties which are not of type "number" or "string".

Tests have been updated accordingly
