### PR TITLE
Drop not needed dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,8 @@ const uidNumber = require('uid-number')
 const umask = require('umask')
 const which = require('which')
 const byline = require('byline')
-const resolveFrom = require('resolve-from')
 
-const DEFAULT_NODE_GYP_PATH = resolveFrom(__dirname, 'node-gyp/bin/node-gyp')
+const DEFAULT_NODE_GYP_PATH = require.resolve('node-gyp/bin/node-gyp')
 const hookStatCache = new Map()
 
 let PATH = isWindows ? 'Path' : 'PATH'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4007,7 +4007,8 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "byline": "^5.0.0",
     "graceful-fs": "^4.1.15",
     "node-gyp": "^5.0.2",
-    "resolve-from": "^4.0.0",
     "slide": "^1.1.6",
     "uid-number": "0.0.6",
     "umask": "^1.1.0",


### PR DESCRIPTION
Relying on external `resolve-from` seems unjustified, when in this given case same can be achieved via `require.resolve`.

Additional issue (which actually brought me here) is that `resolve-from` module references are not automatically traced by tools as [pkg](https://github.com/zeit/pkg#readme) (while for `require.resolve` they are). That in turn requires additional manual setup when e.g. we want to bundle npm with our project into a single binary.
