### PR TITLE
feat: use loglevel for lifecycle note

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ function runCmd (note, cmd, pkg, env, stage, wd, opts, cb) {
 
   if (opts.log.level !== 'silent') {
     opts.log.clearProgress()
-    console.log(note)
+    opts.log.notice('lifecycle', logid(pkg, stage), note)
     opts.log.showProgress()
   }
   opts.log.verbose('lifecycle', logid(pkg, stage), 'unsafe-perm in lifecycle', unsafe)


### PR DESCRIPTION
Currently there's no way to disable the lifecycle notes, except setting loglevel to `silent`, which will remove all logs.

