### PR TITLE
fix: Prevent crash with nameless package

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function lifecycle (pkg, stage, wd, opts) {
 }
 
 function _incorrectWorkingDirectory (wd, pkg) {
-  return wd.lastIndexOf(pkg.name) !== wd.length - pkg.name.length
+  return wd.lastIndexOf(pkg.name) !== wd.length - (typeof pkg.name === 'string' ? pkg.name.length : 0)
 }
 
 function lifecycle_ (pkg, stage, wd, opts, env, cb) {


### PR DESCRIPTION
Not every `package.json` has a name: while npm warns if a name is not provided, it is not required. In my case I have one that should NOT have a name as it's being used only for dependency management, not package description. I know, it's an edge case.

```sh
$ npm -v
6.14.5
```

The workaround is to simply add a name to the package.

I tripped across this myself and found I wasn't the first one: https://stackoverflow.com/questions/59777226/npm-ci-throws-exception-cannot-read-property-length-of-undefined